### PR TITLE
Add AWS AuthError Handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@nekonomokochan/aws-env-creator",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nekonomokochan/aws-env-creator",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "Create an env file from AWS Secrets Manager.",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/src/factories.ts
+++ b/src/factories.ts
@@ -1,5 +1,6 @@
 import { SecretsManager, SharedIniFileCredentials, SSM } from "aws-sdk";
 import { AwsRegion } from "./AwsRegion";
+import AwsEnvCreatorError from "./error/AwsEnvCreatorError";
 
 export interface ICreateSecretsManagerClientParams {
   region: AwsRegion;
@@ -14,27 +15,35 @@ export interface ICreateParameterStoreClientParams {
 export const createSecretsManagerClient = (
   params: ICreateSecretsManagerClientParams
 ): SecretsManager => {
-  if (typeof params.profile === "string") {
-    const credentials = new SharedIniFileCredentials({
-      profile: params.profile,
-    });
+  try {
+    if (typeof params.profile === "string") {
+      const credentials = new SharedIniFileCredentials({
+        profile: params.profile,
+      });
 
-    return new SecretsManager({ region: params.region, credentials });
+      return new SecretsManager({ region: params.region, credentials });
+    }
+
+    return new SecretsManager({ region: params.region });
+  } catch (error) {
+    throw new AwsEnvCreatorError(error.message, error);
   }
-
-  return new SecretsManager({ region: params.region });
 };
 
 export const createParameterStoreClient = (
   params: ICreateParameterStoreClientParams
 ): SSM => {
-  if (typeof params.profile === "string") {
-    const credentials = new SharedIniFileCredentials({
-      profile: params.profile,
-    });
+  try {
+    if (typeof params.profile === "string") {
+      const credentials = new SharedIniFileCredentials({
+        profile: params.profile,
+      });
 
-    return new SSM({ region: params.region, credentials });
+      return new SSM({ region: params.region, credentials });
+    }
+
+    return new SSM({ region: params.region });
+  } catch (error) {
+    throw new AwsEnvCreatorError(error.message, error);
   }
-
-  return new SSM({ region: params.region });
 };

--- a/test/integration/createEnvFileForDirenv.spec.ts
+++ b/test/integration/createEnvFileForDirenv.spec.ts
@@ -171,4 +171,22 @@ describe("createEnvFile.integrationTest", () => {
         expect(error.name).toBe("InvalidFileTypeError");
       });
   });
+
+  it("should give an authentication error, because the profile name is wrong", async () => {
+    try {
+      const params = {
+        type: EnvFileType.direnv,
+        outputDir: "./",
+        secretIds: ["dev/app"],
+        profile: "unknown",
+        region: AwsRegion.ap_northeast_1,
+      };
+
+      const result = await createEnvFile(params);
+      fail(result);
+    } catch (error) {
+      expect(error.message).toStrictEqual("CredentialsError");
+      expect(error.name).toStrictEqual("AwsEnvCreatorError");
+    }
+  });
 });

--- a/test/integration/createEnvFileForDotenv.spec.ts
+++ b/test/integration/createEnvFileForDotenv.spec.ts
@@ -143,4 +143,22 @@ describe("createEnvFile.integrationTest", () => {
         expect(error.name).toBe("InvalidFileTypeError");
       });
   });
+
+  it("should give an authentication error, because the profile name is wrong", async () => {
+    try {
+      const params = {
+        type: EnvFileType.dotenv,
+        outputDir: "./",
+        secretIds: ["dev/app"],
+        profile: "unknown",
+        region: AwsRegion.ap_northeast_1,
+      };
+
+      const result = await createEnvFile(params);
+      fail(result);
+    } catch (error) {
+      expect(error.message).toStrictEqual("CredentialsError");
+      expect(error.name).toStrictEqual("AwsEnvCreatorError");
+    }
+  });
 });

--- a/test/integration/createEnvFileForTfvars.spec.ts
+++ b/test/integration/createEnvFileForTfvars.spec.ts
@@ -123,4 +123,22 @@ describe("createTfvars.integrationTest", () => {
       expect(expected.includes(data)).toBeTruthy();
     });
   });
+
+  it("should give an authentication error, because the profile name is wrong", async () => {
+    try {
+      const params = {
+        type: EnvFileType.terraform,
+        outputDir: "./",
+        secretIds: ["dev/app"],
+        profile: "unknown",
+        region: AwsRegion.ap_northeast_1,
+      };
+
+      const result = await createEnvFile(params);
+      fail(result);
+    } catch (error) {
+      expect(error.message).toStrictEqual("CredentialsError");
+      expect(error.name).toStrictEqual("AwsEnvCreatorError");
+    }
+  });
 });

--- a/test/integration/createEnvFileFromParameterStore.spec.ts
+++ b/test/integration/createEnvFileFromParameterStore.spec.ts
@@ -65,4 +65,27 @@ describe("createEnvFile.integrationTest", () => {
       expect(expected.includes(data)).toBeTruthy();
     });
   });
+
+  it("should give an authentication error, because the profile name is wrong", async () => {
+    try {
+      const params = {
+        type: EnvFileType.dotenv,
+        outputDir: "./",
+        region: AwsRegion.ap_northeast_1,
+        parameterPath: "/dev/test-app/weather",
+        profile: "unknown",
+        outputWhitelist: ["sendgrid-api-key"],
+        outputFilename: ".env.parameterStore",
+        keyMapping: {
+          "sendgrid-api-key": "SENDGRID_API_KEY",
+        },
+      };
+
+      const result = await createEnvFile(params);
+      fail(result);
+    } catch (error) {
+      expect(error.message).toStrictEqual("CredentialsError");
+      expect(error.name).toStrictEqual("AwsEnvCreatorError");
+    }
+  });
 });

--- a/test/integration/fetchFromParameterStore.spec.ts
+++ b/test/integration/fetchFromParameterStore.spec.ts
@@ -63,4 +63,23 @@ describe("fetchFromParameterStore.integrationTest", () => {
 
     expect(storeParamsList).toHaveLength(21);
   });
+
+  it("should give an authentication error, because the profile name is wrong", async () => {
+    try {
+      const parameterStore = createParameterStoreClient({
+        profile: "unknown",
+        region: AwsRegion.ap_northeast_1,
+      });
+
+      const storeParamsList = await fetchFromParameterStore(
+        parameterStore,
+        "/dev/test-app/news"
+      );
+
+      fail(storeParamsList);
+    } catch (error) {
+      expect(error.message).toStrictEqual("CredentialsError");
+      expect(error.name).toStrictEqual("AwsEnvCreatorError");
+    }
+  });
 });

--- a/test/integration/fetchSecretJson.spec.ts
+++ b/test/integration/fetchSecretJson.spec.ts
@@ -35,4 +35,19 @@ describe("fetchSecretJson.integrationTest", () => {
 
     expect(secretJson).toEqual(expectedJson);
   });
+
+  it("should give an authentication error, because the profile name is wrong", async () => {
+    try {
+      const secretsManager = createSecretsManagerClient({
+        profile: "unknown",
+        region: AwsRegion.ap_northeast_1,
+      });
+
+      const secretJson = await fetchSecretJson(secretsManager, "dev/app");
+      fail(secretJson);
+    } catch (error) {
+      expect(error.message).toStrictEqual("CredentialsError");
+      expect(error.name).toStrictEqual("AwsEnvCreatorError");
+    }
+  });
 });


### PR DESCRIPTION
# issueURL
https://github.com/nekonomokochan/aws-env-creator/issues/55

# Done
- A test case has been added when authentication fails due to invalid AWS profile

# Summary of Changes
- Fixed to return AwsEnvCreatorError when AWS Client generation Fail
- Added test case when authentication fails due to invalid AWS profile